### PR TITLE
fix(package): Add autocompleter.d.ts definitions to the npm bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "deprecated": false,
   "main": "ag-grid-autocomplete-editor.js",
   "files": [
+    "/autocompleter/autocomplete.d.ts",
     "/ag-grid-autocomplete-editor.d.ts",
     "/ag-grid-autocomplete-editor.js",
     "/ag-grid-autocomplete-editor.js.map",


### PR DESCRIPTION
Fix #76 