### PR TITLE
fix(minLength): fix minLength cannot set to 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can configure and customize the cell and behavior with the following `cellEd
   - `render`: (`same as classical autocompleter`) function, except that it take the current cellEditor as first parameter.
   - `renderGroup`: (`same as classical autocompleter`) function, except that it take the current cellEditor as first parameter.
   - `className`: (`same as classical autocompleter`) default 'ag-cell-editor-autocomplete'
-  - `minLength`: (`same as classical autocompleter`) default 1
+  - `minLength`: (`same as classical autocompleter`) default 1. User has to edit the input to trigger data fetch. Which means if `minLength = 0` and used with fetch, user has to delete input value to be able to show the list. If you just want to show list on focus without any editing action, use `showOnFocus` instead.
   - `showOnFocus`: (`same as classical autocompleter`) default false trigger first fetch call when input is focused
   - `emptyMsg`: (`same as classical autocompleter`) default 'None'
   - `strict`: (` decide if the user can put free text or not`) default true.

--- a/autocompleter/autocomplete.ts
+++ b/autocompleter/autocomplete.ts
@@ -32,7 +32,7 @@ const KEYS_TO_IGNORE = new Set([
   Keys.WindowsKey,
   Keys.Tab,
 ])
-
+const DEFAULT_MIN_LENGTH = 2
 export { AutocompleteItem, EventTrigger, AutocompleteSettings }
 
 export default function autocomplete<T extends AutocompleteItem>(
@@ -51,7 +51,7 @@ export default function autocomplete<T extends AutocompleteItem>(
     strict,
     autoselectfirst,
     onFreeTextSelect,
-    minLength,
+    minLength = DEFAULT_MIN_LENGTH,
     showOnFocus,
     input,
     className,
@@ -61,7 +61,7 @@ export default function autocomplete<T extends AutocompleteItem>(
     renderGroup,
   } = settings
   const debounceWaitMs = settings.debounceWaitMs || 0
-  const minimumInputLength = minLength || 2
+  const minimumInputLength = minLength
   const container: HTMLDivElement = document.createElement('div')
   const containerStyle = container.style
 

--- a/cypress/integration/end-to-end/autocompleter/minlength.test.ts
+++ b/cypress/integration/end-to-end/autocompleter/minlength.test.ts
@@ -35,4 +35,39 @@ describe('autocomplete end-to-end minlength tests', () => {
     // Should show the select list on the page
     cy.get('.autocomplete')
   })
+
+  it('should always show select list when user delete to empty with minLength equals 0', function () {
+    cy.fixture('selectDatas/united.json').as('selectData')
+    // @ts-ignore
+    cy.visit('./cypress/static/autocomplete-test-sandbox.html')
+    // Get the input element and setup autocomplete to it
+    cy.get('#autocompleter').then((indexQueryElement) => {
+      const { selectData } = this
+      autocomplete({
+        autoselectfirst: false,
+        minLength: 0,
+        fetch(search: string, update: <AutocompleteItem>(items: AutocompleteItem[] | false) => void) {
+          update(selectData)
+        },
+        onSelect(item: AutocompleteItem | undefined) {
+          if (item && item.label) {
+            indexQueryElement.val(item.label)
+          } else {
+            indexQueryElement.val('')
+          }
+        },
+        strict: true,
+        input: <HTMLInputElement>indexQueryElement.get(0),
+      })
+    })
+    // Any input value exist before focus won't be counted unless user type or delete something for all cases,
+    // no matter what the minLength is set.
+    cy.get('#autocompleter').click()
+    cy.get('.autocomplete').should('not.exist')
+
+    // Type anything in the input, then delete to empty.
+    cy.get('#autocompleter').type('randomText').clear()
+    // Should show the select list on the page
+    cy.get('.autocomplete')
+  })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
   "packages": {
     "": {
       "version": "0.0.0-development",
+      "dev": true,
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "12.1.1",
@@ -1807,8 +1808,8 @@
       }
     },
     "node_modules/ag-grid-autocomplete-editor": {
-      "link": true,
-      "resolved": ""
+      "resolved": "",
+      "link": true
     },
     "node_modules/ag-grid-community": {
       "version": "25.1.0",
@@ -2633,10 +2634,14 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001207",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001207.tgz",
-      "integrity": "sha512-UPQZdmAsyp2qfCTiMU/zqGSWOYaY9F9LL61V8f+8MrubsaDGpaHD9HRV/EWZGULZn0Hxu48SKzI5DgFwTvHuYw==",
-      "dev": true
+      "version": "1.0.30001258",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001258.tgz",
+      "integrity": "sha512-RBByOG6xWXUp0CR2/WU2amXz3stjKpSl5J1xU49F1n2OxD//uBZO4wCKUiG+QMGf7CHGfDDcqoKriomoGVxTeA==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
     },
     "node_modules/cardinal": {
       "version": "2.1.1",
@@ -11418,6 +11423,11 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -20487,9 +20497,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001207",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001207.tgz",
-          "integrity": "sha512-UPQZdmAsyp2qfCTiMU/zqGSWOYaY9F9LL61V8f+8MrubsaDGpaHD9HRV/EWZGULZn0Hxu48SKzI5DgFwTvHuYw==",
+          "version": "1.0.30001258",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001258.tgz",
+          "integrity": "sha512-RBByOG6xWXUp0CR2/WU2amXz3stjKpSl5J1xU49F1n2OxD//uBZO4wCKUiG+QMGf7CHGfDDcqoKriomoGVxTeA==",
           "dev": true
         },
         "cardinal": {
@@ -31921,9 +31931,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001207",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001207.tgz",
-      "integrity": "sha512-UPQZdmAsyp2qfCTiMU/zqGSWOYaY9F9LL61V8f+8MrubsaDGpaHD9HRV/EWZGULZn0Hxu48SKzI5DgFwTvHuYw==",
+      "version": "1.0.30001258",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001258.tgz",
+      "integrity": "sha512-RBByOG6xWXUp0CR2/WU2amXz3stjKpSl5J1xU49F1n2OxD//uBZO4wCKUiG+QMGf7CHGfDDcqoKriomoGVxTeA==",
       "dev": true
     },
     "cardinal": {


### PR DESCRIPTION
Enable minLength = 0, as it is a different user scenario from showOnFocus. 

But there might be a bug in current version, which is fetch cannot be triggered without editing (type or delete) the input, no matter what's the value exists before focus the input cell. Which is why for the cypress test added has to type in something then delete it to empty to show the list. 
I'm not sure if this is desired performance or not since it's not declared in README. Could you either fix it or make it more clear in README?